### PR TITLE
Revert bad shape assert in matmul

### DIFF
--- a/kernels/matmul.py
+++ b/kernels/matmul.py
@@ -272,7 +272,7 @@ class _matmul(torch.autograd.Function):
             b = b.contiguous()
         # checks constraints
         assert (
-            a.shape[1] == b.shape[2]
+            a.shape[1] == b.shape[0]
         ), f"incompatible dimensions {a.shape} and {b.shape}"
         M, K = a.shape
         _, N = b.shape


### PR DESCRIPTION
Somehow this was changed recently, but it makes no sense: `b` has only two dimensions (see line below), hence 2 isn't a valid index for its shape.