### PR TITLE
Add topology-derived sparse attention kernel

### DIFF
--- a/benchmarking/__init__.py
+++ b/benchmarking/__init__.py
@@ -1,2 +1,10 @@
 from .profiler import Profiler
-from .benchmark_utils import compare_benchmarks
+
+try:
+    from .benchmark_utils import compare_benchmarks
+except ModuleNotFoundError as exc:
+    if exc.name != "pandas":
+        raise
+
+    def compare_benchmarks(*args, **kwargs):
+        raise ModuleNotFoundError("pandas is required to compare benchmarks")

--- a/benchmarking/__init__.py
+++ b/benchmarking/__init__.py
@@ -1,10 +1,2 @@
 from .profiler import Profiler
-
-try:
-    from .benchmark_utils import compare_benchmarks
-except ModuleNotFoundError as exc:
-    if exc.name != "pandas":
-        raise
-
-    def compare_benchmarks(*args, **kwargs):
-        raise ModuleNotFoundError("pandas is required to compare benchmarks")
+from .benchmark_utils import compare_benchmarks

--- a/benchmarking/benchmark_utils.py
+++ b/benchmarking/benchmark_utils.py
@@ -1,8 +1,14 @@
 from typing import Any, Dict
-import pandas as pd
 
 
 def compare_benchmarks(benchmarks: Dict[str, Dict[str, Any]]) -> Dict[str, Any]:
+    try:
+        import pandas as pd
+    except ModuleNotFoundError as exc:
+        if exc.name != "pandas":
+            raise
+        raise ModuleNotFoundError("pandas is required to compare benchmarks") from exc
+
     series_dict = {k: pd.Series(v.values()) for k, v in benchmarks.items()}
     series_dict["kernel_path"] = pd.Series(
         benchmarks[list(benchmarks.keys())[0]].keys()

--- a/benchmarking/topology_sparse_attention.py
+++ b/benchmarking/topology_sparse_attention.py
@@ -1,0 +1,146 @@
+import argparse
+import statistics
+
+import torch
+import torch.nn.functional as F
+import triton
+
+from kernels.topology_sparse_attention import (
+    build_dense_causal_block_schedule,
+    build_topology_block_schedule,
+    dense_masked_attention,
+    scheduled_attention,
+)
+
+
+HEADER = (
+    "| seq | scheduled / dense blocks | block reduction | dense masked ms | "
+    "full causal SDPA ms | Triton dense CSR ms | Triton scheduled ms | "
+    "Triton sparse vs dense CSR | Triton vs SDPA | max abs error |"
+)
+SEPARATOR = "| ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |"
+
+
+def timed_cuda(fn, rounds):
+    for _ in range(5):
+        fn()
+    torch.cuda.synchronize()
+
+    times = []
+    for _ in range(rounds):
+        start = torch.cuda.Event(enable_timing=True)
+        end = torch.cuda.Event(enable_timing=True)
+        start.record()
+        fn()
+        end.record()
+        torch.cuda.synchronize()
+        times.append(start.elapsed_time(end))
+    return statistics.median(times)
+
+
+def run_case(seq, dim, block_size, rounds):
+    torch.manual_seed(20260629 + seq)
+    q = torch.randn((seq, dim), device="cuda", dtype=torch.float16)
+    k = torch.randn((seq, dim), device="cuda", dtype=torch.float16)
+    v = torch.randn((seq, dim), device="cuda", dtype=torch.float16)
+    offsets, indices = build_topology_block_schedule(
+        k.float(),
+        block_size=block_size,
+        local_radius_blocks=1,
+        sink_blocks=1,
+        topk_topology_blocks=max(1, seq // block_size // 8),
+    )
+    dense_offsets, dense_indices = build_dense_causal_block_schedule(seq // block_size)
+    offsets_cuda = offsets.to("cuda")
+    indices_cuda = indices.to("cuda")
+    dense_offsets_cuda = dense_offsets.to("cuda")
+    dense_indices_cuda = dense_indices.to("cuda")
+
+    expected = dense_masked_attention(
+        q.float(), k.float(), v.float(), offsets, indices, block_size
+    )
+    actual = scheduled_attention(q, k, v, offsets_cuda, indices_cuda, block_size)
+    torch.testing.assert_close(actual.float(), expected, rtol=3e-2, atol=3e-2)
+    dense_expected = dense_masked_attention(
+        q.float(), k.float(), v.float(), dense_offsets, dense_indices, block_size
+    )
+    dense_actual = scheduled_attention(
+        q, k, v, dense_offsets_cuda, dense_indices_cuda, block_size
+    )
+    torch.testing.assert_close(
+        dense_actual.float(), dense_expected, rtol=3e-2, atol=3e-2
+    )
+
+    dense_masked_ms = timed_cuda(
+        lambda: dense_masked_attention(
+            q.float(), k.float(), v.float(), offsets, indices, block_size
+        ),
+        rounds,
+    )
+    sdpa_ms = timed_cuda(
+        lambda: F.scaled_dot_product_attention(
+            q[None, None], k[None, None], v[None, None], is_causal=True
+        ),
+        rounds,
+    )
+    triton_scheduled_ms = timed_cuda(
+        lambda: scheduled_attention(q, k, v, offsets_cuda, indices_cuda, block_size),
+        rounds,
+    )
+    triton_dense_csr_ms = timed_cuda(
+        lambda: scheduled_attention(
+            q, k, v, dense_offsets_cuda, dense_indices_cuda, block_size
+        ),
+        rounds,
+    )
+    return {
+        "seq": seq,
+        "scheduled_blocks": indices.numel(),
+        "dense_blocks": dense_indices.numel(),
+        "block_reduction": 1.0 - indices.numel() / dense_indices.numel(),
+        "dense_masked_ms": dense_masked_ms,
+        "sdpa_ms": sdpa_ms,
+        "triton_dense_csr_ms": triton_dense_csr_ms,
+        "triton_scheduled_ms": triton_scheduled_ms,
+        "sparse_vs_dense_csr": triton_dense_csr_ms / triton_scheduled_ms,
+        "sparse_vs_sdpa": sdpa_ms / triton_scheduled_ms,
+        "max_abs_error": (actual.float() - expected).abs().max().item(),
+    }
+
+
+def format_markdown_row(result):
+    return (
+        "| {seq} | {scheduled_blocks} / {dense_blocks} | {block_reduction:.1%} | "
+        "{dense_masked_ms:.3f} | {sdpa_ms:.3f} | {triton_dense_csr_ms:.3f} | "
+        "{triton_scheduled_ms:.3f} | {sparse_vs_dense_csr:.2f}x | "
+        "{sparse_vs_sdpa:.2f}x | {max_abs_error:.4f} |"
+    ).format(**result)
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Benchmark topology-derived CSR scheduled sparse attention."
+    )
+    parser.add_argument("--seq", type=int, nargs="*", default=[1024, 2048, 4096])
+    parser.add_argument("--dim", type=int, default=64)
+    parser.add_argument("--block-size", type=int, default=64)
+    parser.add_argument("--rounds", type=int, default=50)
+    args = parser.parse_args()
+
+    if not torch.cuda.is_available():
+        raise SystemExit("CUDA is required")
+
+    print(f"GPU: {torch.cuda.get_device_name()}")
+    print(f"PyTorch: {torch.__version__}")
+    print(f"Triton: {triton.__version__}")
+    print(HEADER)
+    print(SEPARATOR)
+    for seq in args.seq:
+        result = run_case(
+            seq=seq, dim=args.dim, block_size=args.block_size, rounds=args.rounds
+        )
+        print(format_markdown_row(result))
+
+
+if __name__ == "__main__":
+    main()

--- a/kernels/__init__.py
+++ b/kernels/__init__.py
@@ -3,6 +3,12 @@ from . import blocksparse
 from .cross_entropy import _cross_entropy, cross_entropy
 from .flash_attention import attention
 from .matmul import _matmul, get_higher_dtype, matmul
+from .topology_sparse_attention import (
+    build_dense_causal_block_schedule,
+    build_topology_block_schedule,
+    dense_masked_attention,
+    scheduled_attention,
+)
 
 # SM120 Gluon flash attention requires triton.experimental.gluon (SM12x only)
 try:
@@ -18,5 +24,9 @@ __all__ = [
     "matmul",
     "attention",
     "attention_forward_sm120",
+    "build_dense_causal_block_schedule",
+    "build_topology_block_schedule",
+    "dense_masked_attention",
     "get_higher_dtype",
+    "scheduled_attention",
 ]

--- a/kernels/topology_sparse_attention.py
+++ b/kernels/topology_sparse_attention.py
@@ -8,6 +8,7 @@ import triton.language as tl
 
 
 _SUPPORTED_HEAD_DIMS = {16, 32, 64, 128}
+_SCHEDULE_DTYPES = {torch.int32, torch.int64}
 
 
 def _is_power_of_two(value):
@@ -256,6 +257,8 @@ def scheduled_attention(q, k, v, offsets, indices, block_size):
         raise ValueError("offsets must have shape [num_query_blocks + 1]")
     if indices.ndim != 1:
         raise ValueError("indices must be a 1D tensor")
+    if offsets.dtype not in _SCHEDULE_DTYPES or indices.dtype not in _SCHEDULE_DTYPES:
+        raise ValueError("offsets and indices must be integer tensors")
     if not q.is_cuda or not k.is_cuda or not v.is_cuda:
         raise ValueError("q, k, and v must be CUDA tensors")
     if offsets.device != q.device or indices.device != q.device:

--- a/kernels/topology_sparse_attention.py
+++ b/kernels/topology_sparse_attention.py
@@ -117,8 +117,8 @@ def build_topology_block_schedule(
         indices.extend(sorted(allowed))
         offsets.append(len(indices))
 
-    return torch.tensor(offsets, dtype=torch.int64), torch.tensor(
-        indices, dtype=torch.int64
+    return torch.tensor(offsets, dtype=torch.int64, device=keys.device), torch.tensor(
+        indices, dtype=torch.int64, device=keys.device
     )
 
 

--- a/kernels/topology_sparse_attention.py
+++ b/kernels/topology_sparse_attention.py
@@ -1,0 +1,271 @@
+"""Forward attention over topology-derived causal CSR block schedules."""
+
+import math
+
+import torch
+import triton
+import triton.language as tl
+
+
+def _zero_dim_persistence_salience(centroids):
+    if centroids.ndim != 2:
+        raise ValueError("centroids must have shape [num_blocks, dim]")
+    num_blocks = centroids.shape[0]
+    if num_blocks == 0:
+        raise ValueError("at least one block is required")
+    if num_blocks == 1:
+        return torch.ones((1,), dtype=centroids.dtype, device=centroids.device)
+
+    cpu_centroids = centroids.detach().to("cpu", torch.float64)
+    distances = torch.cdist(cpu_centroids, cpu_centroids)
+    edges = []
+    for i in range(num_blocks):
+        for j in range(i + 1, num_blocks):
+            edges.append((float(distances[i, j]), i, j))
+    edges.sort(key=lambda item: item[0])
+
+    parent = list(range(num_blocks))
+    members = {i: {i} for i in range(num_blocks)}
+    salience = torch.zeros((num_blocks,), dtype=torch.float64)
+
+    def find(x):
+        while parent[x] != x:
+            parent[x] = parent[parent[x]]
+            x = parent[x]
+        return x
+
+    for distance, left, right in edges:
+        root_left = find(left)
+        root_right = find(right)
+        if root_left == root_right:
+            continue
+        if len(members[root_left]) > len(members[root_right]):
+            root_left, root_right = root_right, root_left
+
+        for block in members[root_left]:
+            salience[block] = distance
+        parent[root_left] = root_right
+        members[root_right].update(members[root_left])
+        del members[root_left]
+
+    return salience.to(device=centroids.device, dtype=centroids.dtype)
+
+
+def build_dense_causal_block_schedule(num_blocks):
+    """Build a lower-triangular CSR schedule over causal key blocks."""
+    offsets = [0]
+    indices = []
+    for q_block in range(num_blocks):
+        indices.extend(range(q_block + 1))
+        offsets.append(len(indices))
+    return torch.tensor(offsets, dtype=torch.int64), torch.tensor(
+        indices, dtype=torch.int64
+    )
+
+
+def build_topology_block_schedule(
+    keys,
+    block_size,
+    local_radius_blocks,
+    sink_blocks,
+    topk_topology_blocks,
+):
+    """Build a causal CSR schedule from sink, local, and topological key blocks."""
+    if keys.ndim != 2:
+        raise ValueError("keys must have shape [seq, dim]")
+    if block_size <= 0:
+        raise ValueError("block_size must be positive")
+    if keys.shape[0] % block_size != 0:
+        raise ValueError("sequence length must be divisible by block_size")
+
+    num_blocks = keys.shape[0] // block_size
+    centroids = keys.reshape(num_blocks, block_size, keys.shape[1]).mean(dim=1)
+    salience = _zero_dim_persistence_salience(centroids)
+    topk = min(max(topk_topology_blocks, 0), num_blocks)
+    if topk:
+        topology_blocks = set(torch.topk(salience, k=topk).indices.tolist())
+    else:
+        topology_blocks = set()
+
+    offsets = [0]
+    indices = []
+    for q_block in range(num_blocks):
+        allowed = set(range(min(sink_blocks, num_blocks)))
+        allowed.update(range(max(0, q_block - local_radius_blocks), q_block + 1))
+        allowed.update(block for block in topology_blocks if block <= q_block)
+        allowed = {block for block in allowed if block <= q_block}
+        if not allowed:
+            allowed.add(q_block)
+
+        indices.extend(sorted(allowed))
+        offsets.append(len(indices))
+
+    return torch.tensor(offsets, dtype=torch.int64), torch.tensor(
+        indices, dtype=torch.int64
+    )
+
+
+def dense_masked_attention(q, k, v, offsets, indices, block_size):
+    """Reference attention for a CSR schedule, implemented with PyTorch masking."""
+    num_blocks = q.shape[0] // block_size
+    allow = torch.zeros((q.shape[0], k.shape[0]), dtype=torch.bool, device=q.device)
+    for q_block in range(num_blocks):
+        q_slice = slice(q_block * block_size, (q_block + 1) * block_size)
+        start = int(offsets[q_block].item())
+        end = int(offsets[q_block + 1].item())
+        for block in indices[start:end]:
+            block = int(block.item())
+            k_slice = slice(block * block_size, (block + 1) * block_size)
+            allow[q_slice, k_slice] = True
+
+    positions = torch.arange(q.shape[0], device=q.device)
+    allow &= positions[None, :] <= positions[:, None]
+    logits = (q @ k.T) / math.sqrt(q.shape[1])
+    logits = logits.masked_fill(~allow, float("-inf"))
+    return torch.softmax(logits, dim=-1) @ v
+
+
+@triton.jit
+def _scheduled_attention_kernel(
+    q_ptr,
+    k_ptr,
+    v_ptr,
+    offsets_ptr,
+    indices_ptr,
+    out_ptr,
+    seq: tl.constexpr,
+    stride_qb: tl.constexpr,
+    stride_qm: tl.constexpr,
+    stride_qd: tl.constexpr,
+    stride_kb: tl.constexpr,
+    stride_kn: tl.constexpr,
+    stride_kd: tl.constexpr,
+    stride_vb: tl.constexpr,
+    stride_vn: tl.constexpr,
+    stride_vd: tl.constexpr,
+    stride_ob: tl.constexpr,
+    stride_om: tl.constexpr,
+    stride_od: tl.constexpr,
+    scale: tl.constexpr,
+    BLOCK_M: tl.constexpr,
+    BLOCK_N: tl.constexpr,
+    HEAD_DIM: tl.constexpr,
+):
+    q_block = tl.program_id(0)
+    batch_block = tl.program_id(1)
+    offs_m = q_block * BLOCK_M + tl.arange(0, BLOCK_M)
+    offs_n = tl.arange(0, BLOCK_N)
+    offs_d = tl.arange(0, HEAD_DIM)
+
+    q = tl.load(
+        q_ptr
+        + batch_block * stride_qb
+        + offs_m[:, None] * stride_qm
+        + offs_d[None, :] * stride_qd,
+        mask=offs_m[:, None] < seq,
+        other=0.0,
+    )
+
+    m_i = tl.full((BLOCK_M,), -float("inf"), tl.float32)
+    l_i = tl.zeros((BLOCK_M,), tl.float32)
+    acc = tl.zeros((BLOCK_M, HEAD_DIM), tl.float32)
+
+    schedule_ptr = tl.load(offsets_ptr + q_block)
+    schedule_end = tl.load(offsets_ptr + q_block + 1)
+    while schedule_ptr < schedule_end:
+        k_block = tl.load(indices_ptr + schedule_ptr)
+        k_pos = k_block * BLOCK_N + offs_n
+
+        k_tile = tl.load(
+            k_ptr
+            + batch_block * stride_kb
+            + k_pos[:, None] * stride_kn
+            + offs_d[None, :] * stride_kd,
+            mask=k_pos[:, None] < seq,
+            other=0.0,
+        )
+        scores = tl.dot(q, tl.trans(k_tile)) * scale
+        valid = (
+            (offs_m[:, None] < seq)
+            & (k_pos[None, :] < seq)
+            & (k_pos[None, :] <= offs_m[:, None])
+        )
+        scores = tl.where(valid, scores, -float("inf"))
+
+        m_ij = tl.maximum(m_i, tl.max(scores, 1))
+        p = tl.exp(scores - m_ij[:, None])
+        alpha = tl.exp(m_i - m_ij)
+
+        v_tile = tl.load(
+            v_ptr
+            + batch_block * stride_vb
+            + k_pos[:, None] * stride_vn
+            + offs_d[None, :] * stride_vd,
+            mask=k_pos[:, None] < seq,
+            other=0.0,
+        )
+        acc = acc * alpha[:, None] + tl.dot(p.to(tl.float32), v_tile.to(tl.float32))
+        l_i = l_i * alpha + tl.sum(p, 1)
+        m_i = m_ij
+        schedule_ptr += 1
+
+    out = acc / l_i[:, None]
+    tl.store(
+        out_ptr
+        + batch_block * stride_ob
+        + offs_m[:, None] * stride_om
+        + offs_d[None, :] * stride_od,
+        out,
+        mask=offs_m[:, None] < seq,
+    )
+
+
+def scheduled_attention(q, k, v, offsets, indices, block_size):
+    """Run forward causal attention over the key/value blocks in a CSR schedule."""
+    if q.shape != k.shape or q.shape != v.shape:
+        raise ValueError("q, k, and v must have the same shape")
+    if q.ndim not in (2, 4):
+        raise ValueError(
+            "q, k, and v must have shape [seq, dim] or [batch, heads, seq, dim]"
+        )
+    if q.shape[-2] % block_size != 0:
+        raise ValueError("sequence length must be divisible by block_size")
+
+    output_shape = q.shape
+    q = q.contiguous()
+    k = k.contiguous()
+    v = v.contiguous()
+    offsets = offsets.contiguous()
+    indices = indices.contiguous()
+    seq, head_dim = q.shape[-2:]
+    q_flat = q.reshape(-1, seq, head_dim)
+    k_flat = k.reshape(-1, seq, head_dim)
+    v_flat = v.reshape(-1, seq, head_dim)
+    out = torch.empty_like(q_flat, dtype=torch.float32)
+    _scheduled_attention_kernel[(seq // block_size, q_flat.shape[0])](
+        q_flat,
+        k_flat,
+        v_flat,
+        offsets,
+        indices,
+        out,
+        seq,
+        q_flat.stride(0),
+        q_flat.stride(1),
+        q_flat.stride(2),
+        k_flat.stride(0),
+        k_flat.stride(1),
+        k_flat.stride(2),
+        v_flat.stride(0),
+        v_flat.stride(1),
+        v_flat.stride(2),
+        out.stride(0),
+        out.stride(1),
+        out.stride(2),
+        1.0 / math.sqrt(head_dim),
+        BLOCK_M=block_size,
+        BLOCK_N=block_size,
+        HEAD_DIM=head_dim,
+        num_warps=4,
+    )
+    return out.reshape(output_shape)

--- a/kernels/topology_sparse_attention.py
+++ b/kernels/topology_sparse_attention.py
@@ -7,6 +7,13 @@ import triton
 import triton.language as tl
 
 
+_SUPPORTED_HEAD_DIMS = {16, 32, 64, 128}
+
+
+def _is_power_of_two(value):
+    return value > 0 and value & (value - 1) == 0
+
+
 def _zero_dim_persistence_salience(centroids):
     if centroids.ndim != 2:
         raise ValueError("centroids must have shape [num_blocks, dim]")
@@ -228,8 +235,22 @@ def scheduled_attention(q, k, v, offsets, indices, block_size):
         raise ValueError(
             "q, k, and v must have shape [seq, dim] or [batch, heads, seq, dim]"
         )
+    if not _is_power_of_two(block_size):
+        raise ValueError("block_size must be a positive power of two")
     if q.shape[-2] % block_size != 0:
         raise ValueError("sequence length must be divisible by block_size")
+
+    seq, head_dim = q.shape[-2:]
+    if head_dim not in _SUPPORTED_HEAD_DIMS:
+        raise ValueError("head dimension must be one of 16, 32, 64, or 128")
+    if offsets.ndim != 1 or offsets.numel() != seq // block_size + 1:
+        raise ValueError("offsets must have shape [num_query_blocks + 1]")
+    if indices.ndim != 1:
+        raise ValueError("indices must be a 1D tensor")
+    if not q.is_cuda or not k.is_cuda or not v.is_cuda:
+        raise ValueError("q, k, and v must be CUDA tensors")
+    if offsets.device != q.device or indices.device != q.device:
+        raise ValueError("offsets and indices must be on the same device as q")
 
     output_shape = q.shape
     q = q.contiguous()
@@ -237,7 +258,6 @@ def scheduled_attention(q, k, v, offsets, indices, block_size):
     v = v.contiguous()
     offsets = offsets.contiguous()
     indices = indices.contiguous()
-    seq, head_dim = q.shape[-2:]
     q_flat = q.reshape(-1, seq, head_dim)
     k_flat = k.reshape(-1, seq, head_dim)
     v_flat = v.reshape(-1, seq, head_dim)

--- a/kernels/topology_sparse_attention.py
+++ b/kernels/topology_sparse_attention.py
@@ -241,7 +241,7 @@ def scheduled_attention(q, k, v, offsets, indices, block_size):
     q_flat = q.reshape(-1, seq, head_dim)
     k_flat = k.reshape(-1, seq, head_dim)
     v_flat = v.reshape(-1, seq, head_dim)
-    out = torch.empty_like(q_flat, dtype=torch.float32)
+    out = torch.empty_like(q_flat)
     _scheduled_attention_kernel[(seq // block_size, q_flat.shape[0])](
         q_flat,
         k_flat,

--- a/kernels/topology_sparse_attention.py
+++ b/kernels/topology_sparse_attention.py
@@ -60,6 +60,9 @@ def _zero_dim_persistence_salience(centroids):
 
 def build_dense_causal_block_schedule(num_blocks):
     """Build a lower-triangular CSR schedule over causal key blocks."""
+    if num_blocks <= 0:
+        raise ValueError("num_blocks must be positive")
+
     offsets = [0]
     indices = []
     for q_block in range(num_blocks):
@@ -84,6 +87,12 @@ def build_topology_block_schedule(
         raise ValueError("block_size must be positive")
     if keys.shape[0] % block_size != 0:
         raise ValueError("sequence length must be divisible by block_size")
+    if local_radius_blocks < 0:
+        raise ValueError("local_radius_blocks must be non-negative")
+    if sink_blocks < 0:
+        raise ValueError("sink_blocks must be non-negative")
+    if topk_topology_blocks < 0:
+        raise ValueError("topk_topology_blocks must be non-negative")
 
     num_blocks = keys.shape[0] // block_size
     centroids = keys.reshape(num_blocks, block_size, keys.shape[1]).mean(dim=1)

--- a/test/test_topology_sparse_attention.py
+++ b/test/test_topology_sparse_attention.py
@@ -1,0 +1,130 @@
+import pytest
+import torch
+
+import kernels.topology_sparse_attention as topology_sparse_attention
+from kernels.topology_sparse_attention import (
+    build_dense_causal_block_schedule,
+    build_topology_block_schedule,
+    dense_masked_attention,
+    scheduled_attention,
+)
+
+
+def test_scheduled_attention_is_exported_from_kernels_package():
+    from kernels import scheduled_attention
+
+    assert scheduled_attention is topology_sparse_attention.scheduled_attention
+
+
+def test_dense_causal_block_schedule_is_lower_triangular_csr():
+    offsets, indices = build_dense_causal_block_schedule(4)
+
+    assert offsets.tolist() == [0, 1, 3, 6, 10]
+    assert indices.tolist() == [0, 0, 1, 0, 1, 2, 0, 1, 2, 3]
+
+
+def test_topology_schedule_adds_persistent_block_outside_local_window():
+    centroids = torch.tensor(
+        [
+            [0.0, 0.0],
+            [100.0, 0.0],
+            [101.0, 0.0],
+            [102.0, 0.0],
+        ]
+    )
+    keys = centroids.repeat_interleave(2, dim=0)
+
+    local_offsets, local_indices = build_topology_block_schedule(
+        keys,
+        block_size=2,
+        local_radius_blocks=0,
+        sink_blocks=0,
+        topk_topology_blocks=0,
+    )
+    topology_offsets, topology_indices = build_topology_block_schedule(
+        keys,
+        block_size=2,
+        local_radius_blocks=0,
+        sink_blocks=0,
+        topk_topology_blocks=1,
+    )
+
+    assert local_indices[local_offsets[3] : local_offsets[4]].tolist() == [3]
+    assert topology_indices[topology_offsets[3] : topology_offsets[4]].tolist() == [
+        0,
+        3,
+    ]
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA is required")
+def test_scheduled_attention_matches_dense_masked_reference():
+    torch.manual_seed(0)
+    seq = 128
+    head_dim = 32
+    block_size = 32
+    q = torch.randn((seq, head_dim), device="cuda", dtype=torch.float16)
+    k = torch.randn((seq, head_dim), device="cuda", dtype=torch.float16)
+    v = torch.randn((seq, head_dim), device="cuda", dtype=torch.float16)
+    offsets, indices = build_topology_block_schedule(
+        k.float(),
+        block_size=block_size,
+        local_radius_blocks=1,
+        sink_blocks=1,
+        topk_topology_blocks=1,
+    )
+
+    expected = dense_masked_attention(
+        q.float(), k.float(), v.float(), offsets, indices, block_size
+    )
+    actual = scheduled_attention(
+        q,
+        k,
+        v,
+        offsets.to(device="cuda"),
+        indices.to(device="cuda"),
+        block_size,
+    )
+
+    torch.testing.assert_close(actual, expected, rtol=3e-2, atol=3e-2)
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA is required")
+def test_scheduled_attention_supports_batch_and_heads():
+    torch.manual_seed(1)
+    batch = 2
+    heads = 3
+    seq = 128
+    head_dim = 32
+    block_size = 32
+    q = torch.randn((batch, heads, seq, head_dim), device="cuda", dtype=torch.float16)
+    k = torch.randn((batch, heads, seq, head_dim), device="cuda", dtype=torch.float16)
+    v = torch.randn((batch, heads, seq, head_dim), device="cuda", dtype=torch.float16)
+    offsets, indices = build_topology_block_schedule(
+        k[0, 0].float(),
+        block_size=block_size,
+        local_radius_blocks=1,
+        sink_blocks=1,
+        topk_topology_blocks=1,
+    )
+
+    expected = torch.empty_like(q, dtype=torch.float32)
+    for batch_idx in range(batch):
+        for head_idx in range(heads):
+            expected[batch_idx, head_idx] = dense_masked_attention(
+                q[batch_idx, head_idx].float(),
+                k[batch_idx, head_idx].float(),
+                v[batch_idx, head_idx].float(),
+                offsets,
+                indices,
+                block_size,
+            )
+    actual = scheduled_attention(
+        q,
+        k,
+        v,
+        offsets.to(device="cuda"),
+        indices.to(device="cuda"),
+        block_size,
+    )
+
+    torch.testing.assert_close(actual, expected, rtol=3e-2, atol=3e-2)

--- a/test/test_topology_sparse_attention.py
+++ b/test/test_topology_sparse_attention.py
@@ -105,6 +105,29 @@ def test_scheduled_attention_rejects_cpu_schedule_for_cuda_inputs():
         scheduled_attention(q, q, q, offsets, indices, 16)
 
 
+def test_topology_sparse_attention_benchmark_formats_markdown_row():
+    from benchmarking.topology_sparse_attention import format_markdown_row
+
+    result = {
+        "seq": 1024,
+        "scheduled_blocks": 59,
+        "dense_blocks": 136,
+        "block_reduction": 0.566,
+        "dense_masked_ms": 2.341,
+        "sdpa_ms": 0.085,
+        "triton_dense_csr_ms": 0.098,
+        "triton_scheduled_ms": 0.094,
+        "sparse_vs_dense_csr": 1.042,
+        "sparse_vs_sdpa": 0.904,
+        "max_abs_error": 0.0009,
+    }
+
+    assert format_markdown_row(result) == (
+        "| 1024 | 59 / 136 | 56.6% | 2.341 | 0.085 | 0.098 | 0.094 | "
+        "1.04x | 0.90x | 0.0009 |"
+    )
+
+
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA is required")
 def test_scheduled_attention_matches_dense_masked_reference():
     torch.manual_seed(0)

--- a/test/test_topology_sparse_attention.py
+++ b/test/test_topology_sparse_attention.py
@@ -10,6 +10,27 @@ from kernels.topology_sparse_attention import (
 )
 
 
+def test_benchmark_utils_defers_optional_pandas_import(monkeypatch):
+    import builtins
+    import importlib
+    import sys
+
+    sys.modules.pop("benchmarking", None)
+    sys.modules.pop("benchmarking.benchmark_utils", None)
+    real_import = builtins.__import__
+
+    def import_without_pandas(name, *args, **kwargs):
+        if name == "pandas" or name.startswith("pandas."):
+            raise ModuleNotFoundError("No module named 'pandas'", name="pandas")
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", import_without_pandas)
+
+    benchmark_utils = importlib.import_module("benchmarking.benchmark_utils")
+    with pytest.raises(ModuleNotFoundError, match="pandas"):
+        benchmark_utils.compare_benchmarks({"triton": {"kernel": 1.0}})
+
+
 def test_scheduled_attention_is_exported_from_kernels_package():
     from kernels import scheduled_attention
 

--- a/test/test_topology_sparse_attention.py
+++ b/test/test_topology_sparse_attention.py
@@ -85,7 +85,30 @@ def test_scheduled_attention_matches_dense_masked_reference():
         block_size,
     )
 
-    torch.testing.assert_close(actual, expected, rtol=3e-2, atol=3e-2)
+    torch.testing.assert_close(actual.float(), expected, rtol=3e-2, atol=3e-2)
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA is required")
+def test_scheduled_attention_preserves_input_dtype():
+    torch.manual_seed(2)
+    seq = 128
+    head_dim = 32
+    block_size = 32
+    q = torch.randn((seq, head_dim), device="cuda", dtype=torch.float16)
+    k = torch.randn((seq, head_dim), device="cuda", dtype=torch.float16)
+    v = torch.randn((seq, head_dim), device="cuda", dtype=torch.float16)
+    offsets, indices = build_dense_causal_block_schedule(seq // block_size)
+
+    actual = scheduled_attention(
+        q,
+        k,
+        v,
+        offsets.to(device="cuda"),
+        indices.to(device="cuda"),
+        block_size,
+    )
+
+    assert actual.dtype == q.dtype
 
 
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA is required")
@@ -127,4 +150,4 @@ def test_scheduled_attention_supports_batch_and_heads():
         block_size,
     )
 
-    torch.testing.assert_close(actual, expected, rtol=3e-2, atol=3e-2)
+    torch.testing.assert_close(actual.float(), expected, rtol=3e-2, atol=3e-2)

--- a/test/test_topology_sparse_attention.py
+++ b/test/test_topology_sparse_attention.py
@@ -56,6 +56,55 @@ def test_topology_schedule_adds_persistent_block_outside_local_window():
     ]
 
 
+def test_scheduled_attention_rejects_non_positive_block_size():
+    q = torch.empty((64, 32), dtype=torch.float16)
+    offsets, indices = build_dense_causal_block_schedule(4)
+
+    with pytest.raises(ValueError, match="block_size"):
+        scheduled_attention(q, q, q, offsets, indices, 0)
+
+
+def test_scheduled_attention_rejects_non_power_of_two_block_size():
+    q = torch.empty((96, 32), dtype=torch.float16)
+    offsets, indices = build_dense_causal_block_schedule(4)
+
+    with pytest.raises(ValueError, match="block_size"):
+        scheduled_attention(q, q, q, offsets, indices, 24)
+
+
+def test_scheduled_attention_rejects_unsupported_head_dimension():
+    q = torch.empty((64, 24), dtype=torch.float16)
+    offsets, indices = build_dense_causal_block_schedule(4)
+
+    with pytest.raises(ValueError, match="head dimension"):
+        scheduled_attention(q, q, q, offsets, indices, 16)
+
+
+def test_scheduled_attention_rejects_mismatched_csr_offsets():
+    q = torch.empty((64, 32), dtype=torch.float16)
+    offsets, indices = build_dense_causal_block_schedule(3)
+
+    with pytest.raises(ValueError, match="offsets"):
+        scheduled_attention(q, q, q, offsets, indices, 16)
+
+
+def test_scheduled_attention_rejects_cpu_inputs():
+    q = torch.empty((64, 32), dtype=torch.float16)
+    offsets, indices = build_dense_causal_block_schedule(4)
+
+    with pytest.raises(ValueError, match="CUDA"):
+        scheduled_attention(q, q, q, offsets, indices, 16)
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA is required")
+def test_scheduled_attention_rejects_cpu_schedule_for_cuda_inputs():
+    q = torch.empty((64, 32), device="cuda", dtype=torch.float16)
+    offsets, indices = build_dense_causal_block_schedule(4)
+
+    with pytest.raises(ValueError, match="same device"):
+        scheduled_attention(q, q, q, offsets, indices, 16)
+
+
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA is required")
 def test_scheduled_attention_matches_dense_masked_reference():
     torch.manual_seed(0)

--- a/test/test_topology_sparse_attention.py
+++ b/test/test_topology_sparse_attention.py
@@ -139,6 +139,31 @@ def test_scheduled_attention_rejects_cpu_schedule_for_cuda_inputs():
         scheduled_attention(q, q, q, offsets, indices, 16)
 
 
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA is required")
+def test_scheduled_attention_rejects_non_integer_schedule_tensors():
+    q = torch.empty((64, 32), device="cuda", dtype=torch.float16)
+    offsets, indices = build_dense_causal_block_schedule(4)
+
+    with pytest.raises(ValueError, match="integer"):
+        scheduled_attention(
+            q,
+            q,
+            q,
+            offsets.to(device="cuda", dtype=torch.float32),
+            indices.to(device="cuda"),
+            16,
+        )
+    with pytest.raises(ValueError, match="integer"):
+        scheduled_attention(
+            q,
+            q,
+            q,
+            offsets.to(device="cuda"),
+            indices.to(device="cuda", dtype=torch.float32),
+            16,
+        )
+
+
 def test_topology_sparse_attention_benchmark_formats_markdown_row():
     from benchmarking.topology_sparse_attention import format_markdown_row
 

--- a/test/test_topology_sparse_attention.py
+++ b/test/test_topology_sparse_attention.py
@@ -188,6 +188,39 @@ def test_topology_sparse_attention_benchmark_formats_markdown_row():
 
 
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA is required")
+def test_topology_schedule_preserves_key_device_for_direct_kernel_use():
+    torch.manual_seed(3)
+    seq = 128
+    head_dim = 32
+    block_size = 32
+    q = torch.randn((seq, head_dim), device="cuda", dtype=torch.float16)
+    k = torch.randn((seq, head_dim), device="cuda", dtype=torch.float16)
+    v = torch.randn((seq, head_dim), device="cuda", dtype=torch.float16)
+    offsets, indices = build_topology_block_schedule(
+        k.float(),
+        block_size=block_size,
+        local_radius_blocks=1,
+        sink_blocks=1,
+        topk_topology_blocks=1,
+    )
+
+    assert offsets.device == k.device
+    assert indices.device == k.device
+
+    expected = dense_masked_attention(
+        q.float(),
+        k.float(),
+        v.float(),
+        offsets.cpu(),
+        indices.cpu(),
+        block_size,
+    )
+    actual = scheduled_attention(q, k, v, offsets, indices, block_size)
+
+    torch.testing.assert_close(actual.float(), expected, rtol=3e-2, atol=3e-2)
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA is required")
 def test_scheduled_attention_matches_dense_masked_reference():
     torch.manual_seed(0)
     seq = 128

--- a/test/test_topology_sparse_attention.py
+++ b/test/test_topology_sparse_attention.py
@@ -56,6 +56,40 @@ def test_topology_schedule_adds_persistent_block_outside_local_window():
     ]
 
 
+def test_dense_causal_block_schedule_rejects_non_positive_block_count():
+    with pytest.raises(ValueError, match="num_blocks"):
+        build_dense_causal_block_schedule(0)
+
+
+def test_topology_block_schedule_rejects_negative_structural_parameters():
+    keys = torch.empty((8, 4))
+
+    with pytest.raises(ValueError, match="local_radius_blocks"):
+        build_topology_block_schedule(
+            keys,
+            block_size=2,
+            local_radius_blocks=-1,
+            sink_blocks=0,
+            topk_topology_blocks=0,
+        )
+    with pytest.raises(ValueError, match="sink_blocks"):
+        build_topology_block_schedule(
+            keys,
+            block_size=2,
+            local_radius_blocks=0,
+            sink_blocks=-1,
+            topk_topology_blocks=0,
+        )
+    with pytest.raises(ValueError, match="topk_topology_blocks"):
+        build_topology_block_schedule(
+            keys,
+            block_size=2,
+            local_radius_blocks=0,
+            sink_blocks=0,
+            topk_topology_blocks=-1,
+        )
+
+
 def test_scheduled_attention_rejects_non_positive_block_size():
     q = torch.empty((64, 32), dtype=torch.float16)
     offsets, indices = build_dense_causal_block_schedule(4)


### PR DESCRIPTION
## Summary

- Add a forward-only Triton scheduled-attention kernel that consumes causal CSR block schedules.
- Add topology-derived schedule construction using sink blocks, local-window blocks, and a 0D-persistence-style salience score over key-block centroids.
- Support both `[seq, dim]` and `[batch, heads, seq, dim]` inputs with the same CSR schedule shared across batch/head lanes.
- Preserve the input dtype for the attention output, and preserve the key tensor device for topology-derived schedules so CUDA schedules can be passed directly to the kernel.
- Validate schedule-builder inputs and wrapper inputs before launch for block size, head dimension, CSR shape, integer schedule dtype, CUDA tensors, and schedule device placement.
- Add a checked-in benchmark runner to reproduce the sparse-vs-dense-CSR table.
- Add tests for public export, dense causal CSR layout, topology block selection, schedule validation, wrapper validation, schedule device preservation, benchmark formatting, dtype preservation, 2D correctness, and batched/headed correctness.

Closes #21.

This was originally attempted in triton-lang/triton#10768. Maintainer feedback there said the Triton core repo was probably not the right place and that a repo of Triton kernels would be a better fit, so this PR moves the contribution here instead of reopening the core PR.

## Local validation

```bash
wsl.exe -d Ubuntu -- bash -lc "cd /mnt/c/Users/seal/Documents/GitHub/kernels && /home/seal/.cache/codex-triton-topology-venv/bin/python -m py_compile benchmarking/__init__.py benchmarking/topology_sparse_attention.py kernels/topology_sparse_attention.py test/test_topology_sparse_attention.py && /home/seal/.cache/codex-triton-topology-venv/bin/python -m pytest -s --tb=short test/test_topology_sparse_attention.py"
```

Result: 17 passed.

```bash
git diff --check -- .
```

Result: no whitespace errors. Git emitted local CRLF warnings only.

Benchmark smoke command:

```bash
wsl.exe -d Ubuntu -- bash -lc "cd /mnt/c/Users/seal/Documents/GitHub/kernels && /home/seal/.cache/codex-triton-topology-venv/bin/python -m benchmarking.topology_sparse_attention --seq 1024 --rounds 3"
```

Result: command completed and printed the markdown benchmark table.

## Local benchmark

To reproduce the full table:

```bash
python -m benchmarking.topology_sparse_attention --seq 1024 2048 4096 --rounds 50
```

Measured on NVIDIA GeForce RTX 4060 Laptop GPU, PyTorch 2.12.1+cu130, Triton 3.7.1, `dim=64`, `block_size=64`, 50 timing rounds.

| seq | scheduled / dense blocks | block reduction | dense masked ms | full causal SDPA ms | Triton dense CSR ms | Triton scheduled ms | Triton sparse vs dense CSR | Triton vs SDPA | max abs error |
| ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
| 1024 | 59 / 136 | 56.6% | 2.341 | 0.085 | 0.098 | 0.094 | 1.04x | 0.90x | 0.0009 |
| 2048 | 114 / 528 | 78.4% | 2.772 | 0.081 | 0.125 | 0.057 | 2.18x | 1.41x | 0.0008 |
| 4096 | 398 / 2080 | 80.9% | 10.192 | 0.186 | 0.242 | 0.070 | 3.48x | 2.68x | 0.0009 |

The main Triton-side comparison is `Triton sparse vs dense CSR`: both sides use this PR's scheduled-attention Triton kernel, but the dense CSR path visits every causal block. The SDPA number is a full-causal optimized baseline, not the same sparse mask; the 1024-token case is slower than SDPA, so this should not be read as a universal SDPA speedup claim.